### PR TITLE
[FIX] some endpoints without data must be called with POST method

### DIFF
--- a/gopay/payments.py
+++ b/gopay/payments.py
@@ -29,16 +29,16 @@ class Payments:
         return self._api('payments/payment/' + str(id_payment) + '/create-recurrence', JSON, payment)
 
     def void_recurrence(self, id_payment):
-        return self._api('payments/payment/' + str(id_payment) + '/void-recurrence', FORM, None)
+        return self._api('payments/payment/' + str(id_payment) + '/void-recurrence', FORM, {})
 
     def capture_authorization(self, id_payment):
-        return self._api('payments/payment/' + str(id_payment) + '/capture', FORM, None)
+        return self._api('payments/payment/' + str(id_payment) + '/capture', FORM, {})
 
     def capture_authorization_partial(self, id_payment, capture_payment):
         return self._api('payments/payment/' + str(id_payment) + '/capture', JSON, capture_payment)
 
     def void_authorization(self, id_payment):
-        return self._api('payments/payment/' + str(id_payment) + '/void-authorization', FORM, None)
+        return self._api('payments/payment/' + str(id_payment) + '/void-authorization', FORM, {})
 
     def get_payment_instruments(self, go_id, currency):
         return self._api('eshops/eshop/' + str(go_id) + '/payment-instruments/' + str(currency), '', None)


### PR DESCRIPTION
Ve třídě GoPay v metodě call se vybírá zda bude požadavek zavolán metodou GET či POST dle toho, zda metoda posílá nějaká data. Jsou ovšem metody, které data neposílají, ale jejich endpoint přijímá pouze POST metody. Zavolá-li se api metoda s paramatrem `data` nastaveným na něco jiného než `None`, správně se vybere metoda POST.